### PR TITLE
feat: Support adding link to internal references

### DIFF
--- a/playground/ts/src/function.ts
+++ b/playground/ts/src/function.ts
@@ -1,11 +1,24 @@
 import {BaseInterface} from './interface'
 
 /**
+ * Test function with link to BaseInterface with custom text
+ *
+ * @public
+ * @param options - Base Interface Link out
+ *  {@link BaseInterface | Custom Text}
+ *
+ * @returns string
+ */
+export function testFunctionLinkWithName(options: BaseInterface): string {
+  return `${options.id} ${options.foo}`
+}
+
+/**
  * Test function with link to BaseInterface
  *
  * @public
  * @param options - Base Interface Link out
- *  {@link BaseInterface | BaseInterface}
+ * {@link BaseInterface}
  *
  * @returns string
  */

--- a/src/core/transform/transformDocComment.ts
+++ b/src/core/transform/transformDocComment.ts
@@ -127,6 +127,7 @@ function _transformDocNode(docNode: DocNode): PortableTextNode | undefined {
 
           fullReferenceURL = memberReferences
             .map((memberReference) => memberReference.memberIdentifier?.identifier)
+            .filter((identifier) => Boolean(identifier))
             .join('/')
 
           if (memberIdentifier) {

--- a/test/_spawnProject.ts
+++ b/test/_spawnProject.ts
@@ -25,7 +25,7 @@ async function _tmpWorkspace() {
   }
 }
 
-export async function _spawnProject(name: string): Promise<{
+export interface _SpawnedProject {
   cwd: string
   add: (pkg: string) => Promise<{stdout: string; stderr: string}>
   dirs: (relativePath?: string) => Promise<string[]>
@@ -35,7 +35,9 @@ export async function _spawnProject(name: string): Promise<{
   remove: () => void
   require: (id: string) => any
   run: (cmd: string) => Promise<{stdout: string; stderr: string}>
-}> {
+}
+
+export async function _spawnProject(name: string): Promise<_SpawnedProject> {
   const {path: tmpPath, remove: tmpRemove} = await _tmpWorkspace()
   const sourcePackagePath = path.resolve(__dirname, '../playground', name)
 


### PR DESCRIPTION
Allows linking to a declaration in the package. For nested interface `.` can be used to reference it and it will convert to a relative url when it gets stored as a document. 

Note: This does not support adding arbitrary text. That is a limitation of the api-extractor, link to [docs](https://api-extractor.com/pages/tsdoc/tag_link/)