### PR TITLE
fix: code highlighting not working when importing only TSDocProvider

### DIFF
--- a/src/react/app/TSDocProvider.tsx
+++ b/src/react/app/TSDocProvider.tsx
@@ -1,7 +1,19 @@
 import {TSDocAppParams, TSDocStore} from '@sanity/tsdoc/store'
 import {ReactElement, ReactNode, useCallback, useEffect, useMemo, useRef} from 'react'
+import Refractor from 'react-refractor'
+import bash from 'refractor/lang/bash'
+import javascript from 'refractor/lang/javascript'
+import json from 'refractor/lang/json'
+import jsx from 'refractor/lang/jsx'
+import typescript from 'refractor/lang/typescript'
 import {compilePath} from './lib/compilePath'
 import {TSDocContext, TSDocContextValue} from './TSDocContext'
+
+Refractor.registerLanguage(bash)
+Refractor.registerLanguage(javascript)
+Refractor.registerLanguage(json)
+Refractor.registerLanguage(jsx)
+Refractor.registerLanguage(typescript)
 
 const EMPTY_PARAMS: TSDocAppParams = {
   exportPath: null,

--- a/src/react/mount.tsx
+++ b/src/react/mount.tsx
@@ -4,19 +4,7 @@ import {ThemeColorSchemeKey, ThemeProvider, studioTheme, usePrefersDark} from '@
 import {createBrowserHistory} from 'history'
 import {StrictMode, useEffect, useMemo, useState} from 'react'
 import {createRoot} from 'react-dom/client'
-import Refractor from 'react-refractor'
-import bash from 'refractor/lang/bash'
-import javascript from 'refractor/lang/javascript'
-import json from 'refractor/lang/json'
-import jsx from 'refractor/lang/jsx'
-import typescript from 'refractor/lang/typescript'
 import {parsePath, TSDocApp} from './app'
-
-Refractor.registerLanguage(bash)
-Refractor.registerLanguage(javascript)
-Refractor.registerLanguage(json)
-Refractor.registerLanguage(jsx)
-Refractor.registerLanguage(typescript)
 
 const EMPTY_ARRAY: never[] = []
 


### PR DESCRIPTION
This fixes issue where only the TSDocProvider is imported in the marketing site which causes the `Refactor.registerLanguage` code path to not be called