### PR TITLE
fix: issue where hidden properties were showing up

### DIFF
--- a/src/store/queries.ts
+++ b/src/store/queries.ts
@@ -385,7 +385,7 @@ export const API_MEMBER_QUERY = groq`
   && !("@hidden" in coalesce(comment.customBlocks[].tag, []))
 ]{
   ${API_MEMBER_PROJECTION},
-
+  "members": members[!("@hidden" in coalesce(comment.customBlocks[].tag, []))],
   'versions': *[
     _type == 'api.release'
     && package->scope == $packageScope


### PR DESCRIPTION
- [x] fixes issue where properties that were tagged as hidden in the tsdoc were still showing up on the website

<img width="738" alt="image" src="https://github.com/sanity-io/tsdoc/assets/6951139/c7fac484-33d0-45af-8b8c-c39dba02017e">

| Before | After |
|-------|-------|
| <img width="574" alt="image" src="https://github.com/sanity-io/tsdoc/assets/6951139/340d1986-cc13-41d3-99fb-80fd9701fac5"> | <img width="633" alt="image" src="https://github.com/sanity-io/tsdoc/assets/6951139/8efe1873-c91e-467f-82c3-91f919ac4583"> |