### PR TITLE
Fix regex to rewrite JSX_2 to JSX

### DIFF
--- a/src/react/article/TSDocCode.tsx
+++ b/src/react/article/TSDocCode.tsx
@@ -40,6 +40,7 @@ export function TSDocCode(props: {
     .replace(/History_2/g, 'History')
     .replace(/React_2/g, 'React')
     .replace(/Plugin_2/g, 'Plugin2')
+    .replace(/JSX_2/g, 'JSX')
 
   return (
     <Root>


### PR DESCRIPTION
This will render "JSX" rather than "JSX_2" in the `Signature` and `Returns` sections of the API Reference.