### PR TITLE
bug(tsdoc): fix various minor style issues

### DIFF
--- a/src/react/comment/CommentExampleBlocks.tsx
+++ b/src/react/comment/CommentExampleBlocks.tsx
@@ -16,14 +16,18 @@ export function CommentExampleBlocks(props: {data: TSDocComment}): ReactElement 
 
       {exampleBlocks.map((exampleBlock, idx: number) => (
         <Level key={exampleBlock._key}>
-          <CommentExampleBlock data={exampleBlock} index={idx} showHeader={showPerExampleHeader}/>
+          <CommentExampleBlock data={exampleBlock} index={idx} showHeader={showPerExampleHeader} />
         </Level>
       ))}
     </>
   )
 }
 
-export function CommentExampleBlock(props: {data: TSDocExampleBlock; index: number; showHeader: boolean}): ReactElement {
+export function CommentExampleBlock(props: {
+  data: TSDocExampleBlock
+  index: number
+  showHeader: boolean
+}): ReactElement {
   const {data, index, showHeader} = props
 
   if (!data.content) return <></>

--- a/src/react/comment/PortableText.tsx
+++ b/src/react/comment/PortableText.tsx
@@ -17,6 +17,7 @@ const CODE_LANGUAGES: Record<string, string> = {
 
 export function PortableText(props: {blocks: PortableTextNode[]}): ReactElement {
   const {blocks} = props
+
   return <BasePortableText components={components} value={blocks} />
 }
 
@@ -51,7 +52,10 @@ function CodeBlock(props: {value: {code?: string; language?: string}}) {
       radius={3}
       tone="inherit"
     >
-      <Code language={CODE_LANGUAGES[language] || language || 'typescript'} size={useTextSize([-1, -1, 0])}>
+      <Code
+        language={CODE_LANGUAGES[language] || language || 'typescript'}
+        size={useTextSize([-1, -1, 0])}
+      >
         {code}
       </Code>
     </Card>


### PR DESCRIPTION
Fixes SDX-661
Fixes SDX-659
Fixes SDX-660

# Increases margin between paragraphs

Before:
<img width="978" alt="image" src="https://github.com/sanity-io/tsdoc/assets/6889008/f2acc30b-3177-4e41-afdc-f0262da58cc3">

After:
<img width="994" alt="image" src="https://github.com/sanity-io/tsdoc/assets/6889008/3b7442cb-5065-4105-a397-4cc074f3a574">

# Removes example header for when there is only one example

Before:
<img width="990" alt="image" src="https://github.com/sanity-io/tsdoc/assets/6889008/d96a4b99-43e1-4824-b397-e7629a9406bb">

After:
<img width="1019" alt="image" src="https://github.com/sanity-io/tsdoc/assets/6889008/ea22926e-8343-40e2-b8e4-cb2889f47e6e">


# Default code blocks to be typescript

Before:
<img width="980" alt="image" src="https://github.com/sanity-io/tsdoc/assets/6889008/1911cdd6-5875-48a6-ab1c-63e8cab68fd1">

After:
<img width="985" alt="image" src="https://github.com/sanity-io/tsdoc/assets/6889008/8eb8bc5b-b47f-414f-a896-dbd314146e9f">
